### PR TITLE
Fix setTerminal typo

### DIFF
--- a/dist/redsys-polite.js
+++ b/dist/redsys-polite.js
@@ -339,7 +339,7 @@ var RedsysBuilder = function () {
   }, {
     key: "setTerminal",
     value: function setTerminal(terminal_number) {
-      this.terminal = terminal_numbver;
+      this.terminal = terminal_number;
       return this;
     }
   }, {


### PR DESCRIPTION
When trying to set the terminal, it throws an error for a typo (terminal_numbver instead of terminal_number)